### PR TITLE
Remove dependency on jQuery.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,12 +13,12 @@
         "Gruntfile.js"
     ],
     "dependencies": {
-        "jquery": ">1.9",
         "angular": ">1.0"
     },
     "devDependencies": {
         "angular": "=1.2.6",
         "angular-mocks": "=1.2.6",
-        "angular-scenario": "=1.2.6"
+        "angular-scenario": "=1.2.6",
+        "jquery": ">1.9"
     }
 }

--- a/src/angular-blocks.js
+++ b/src/angular-blocks.js
@@ -15,45 +15,51 @@
                     throw 'Template not specified in extend-template directive';
                 }
                 // Clone and then clear the template element to prevent expressions from being evaluated
-                var $clone = tElement.clone();
+                var $clone = angular.element(tElement.clone());
                 tElement.html('');
 
                 var loadTemplate = $http.get(src, {cache: $templateCache})
                     .then(function (response) {
-                        var template = response.data;
-                        var $template = $(document.createElement('div')).html(template);
+                        var $template = angular.element(document.createElement('div')).html(response.data);
 
-                        function override(method, $block, attr) {
-                            var name = $block.attr(attr);
-                            if ($template.find('[data-block="' + name + '"]')[method]($block).length === 0 &&
-                                $template.find('[data-extend-template]').append($block).length === 0) {
+                        function override(method, block, attr) {
+                            var name = block[0].getAttribute(attr);
+
+                            if (angular.element($template[0].querySelectorAll('[data-block="' + name + '"]'))[method](block).length === 0 &&
+                                angular.element($template[0].querySelectorAll('[data-extend-template]')).append(block).length === 0) {
                                 warnMissingBlock(name, src);
                             }
                         }
 
-                        // Replace overridden blocks
-                        $clone.children('[data-block]').each(function () {
-                            override('replaceWith', $(this), 'data-block');
-                        });
+                        angular.forEach($clone.children(), function (el) {
+                            var $el = angular.element(el);
 
-                        // Insert prepend blocks
-                        $clone.children('[data-block-prepend]').each(function () {
-                            override('prepend', $(this), 'data-block-prepend');
-                        });
+                            // Replace overridden blocks
+                            if (el.hasAttribute('data-block')) {
+                                override('replaceWith', $el, 'data-block');
+                            }
 
-                        // Insert append blocks
-                        $clone.children('[data-block-append]').each(function () {
-                            override('append', $(this), 'data-block-append');
-                        });
+                            // Insert prepend blocks
+                            if (el.hasAttribute('data-block-prepend')) {
+                                override('prepend', $el, 'data-block-prepend');
+                            }
 
-                        // Insert before blocks
-                        $clone.children('[data-block-before]').each(function () {
-                            override('before', $(this), 'data-block-before');
-                        });
+                            // Insert append blocks
+                            if (el.hasAttribute('data-block-append')) {
+                                override('append', $el, 'data-block-append');
+                            }
 
-                        // Insert after blocks
-                        $clone.children('[data-block-after]').each(function () {
-                            override('after', $(this), 'data-block-after');
+                            // TODO: angular.element does not have a `.before`
+                            // method. Potentially monkey patch this.
+                            // Insert before blocks
+                            // if (el.hasAttribute('data-block-before')) {
+                            //     override('before', $el, 'data-block-before');
+                            // }
+
+                            // Insert after blocks
+                            if (el.hasAttribute('data-block-after')) {
+                                override('after', $el, 'data-block-after');
+                            }
                         });
 
                         return $template;


### PR DESCRIPTION
This remove the dependency on jQuery, and uses angular.element() instead.

All methods have been replaced apart from .
